### PR TITLE
Add Support for OuDiaSecond (`oud2`) File Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ https://marketplace.visualstudio.com/items?itemName=up-tri.oud-intellisense
 
 # oud-intellisense
 
-- syntax highlighting for OuDia file (.oud).
+- syntax highlighting for OuDia file (.oud) and OuDiaSecond file (.oud2).
 - open/close support for each namespaces.
 
 ## Release Notes

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "languages": [{
       "id": "oudia",
       "extensions": [
-        ".oud"
+        ".oud",
+        ".oud2"
       ],
       "configuration": "./language-configuration.json"
     }],


### PR DESCRIPTION
## TL;DR

This PR adds OuDiaSecond (`.oud2`) file format support.

## Background

[OuDiaSecond](http://oudiasecond.seesaa.net/) is a famous OuDia successor that is now widely used for the same purpose. There is a lot of changes especially it adds a lot keys and configurations. However, the file format itself (`.oud2`) does not differ a lot from `.oud` file. The structures are the same, so the same VSCode language extension `oud-intellisense` can be used directly to add support for OuDiaSecond file. However, since this format is not directly supported by this plugin, user must add the following configuration to their settings.

```json
"files.associations": {
  "*.oud2": "oudia"
}
```

## Motivation
Supporting this format ensures that the VSCode extension remains up-to-date with current trends in diagramming software.

## Changes
- Added support for `.oud2` by add the file extension to `extensions` in [`package.json`](https://github.com/up-tri/oud-intellisense/compare/master...yocjyet:oud-intellisense:master#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)
- Updated the [`README.md`](https://github.com/up-tri/oud-intellisense/compare/master...yocjyet:oud-intellisense:master#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to reflect the addition of `.oud2` support. 

## Backward Compatibility
These changes are backward compatible with the existing `.oud` format and should not affect any current users.

Please let me know if any adjustments are needed. I am happy to iterate on this PR. Thank you for your time and consideration!
